### PR TITLE
Fix/issue 222

### DIFF
--- a/signer-npm/js/src/index.js
+++ b/signer-npm/js/src/index.js
@@ -8,7 +8,7 @@ const { MethodInit, MethodPaych } = require("./methods");
 const ExtendedKey = require("./extendedkey");
 const {
   getDigest,
-  getAccountFromPath,
+  getCoinTypeFromPath,
   addressAsBytes,
   bytesToAddress,
   tryToPrivateKeyBuffer,
@@ -30,7 +30,7 @@ function keyDeriveFromSeed(seed, path) {
   const childKey = masterKey.derivePath(path);
 
   let testnet = false;
-  if (getAccountFromPath(path) === "1") {
+  if (getCoinTypeFromPath(path) === "1") {
     testnet = true;
   }
 

--- a/signer-npm/js/src/utils.js
+++ b/signer-npm/js/src/utils.js
@@ -43,7 +43,7 @@ function getChecksum(payload) {
   return Buffer.from(blake.blake2bFinal(blakeCtx));
 }
 
-function getAccountFromPath(path) {
+function getCoinTypeFromPath(path) {
   return path.split("/")[2].slice(0, -1);
 }
 
@@ -159,7 +159,7 @@ module.exports = {
   getDigest,
   getPayloadSECP256K1,
   getChecksum,
-  getAccountFromPath,
+  getCoinTypeFromPath,
   addressAsBytes,
   bytesToAddress,
   tryToPrivateKeyBuffer,


### PR DESCRIPTION
closes issue #222 

Rename function `getAccountFromPath` to `getCoinTypeFromPath` to better reflect the usage of the function.