### PR TITLE
Changes for compatibility with v2 payment channels

### DIFF
--- a/docs/wasm_api.md
+++ b/docs/wasm_api.md
@@ -434,7 +434,7 @@ Deserialize specificaly constructor parameters into javascript object given the 
 
 Arguments :
 * **params**: base64 cbor encoded constructor parameters;
-* **codeCID**: a string giving the actor type (e.g "fil/1/paymentchannel");
+* **codeCID**: a string giving the actor type (e.g "fil/2/paymentchannel");
 
 ```javascript
 const signer_wasm = require('@zondax/filecoin-signing-tools');
@@ -443,7 +443,7 @@ const signer_wasm = require('@zondax/filecoin-signing-tools');
 
 let cbor_base64 = "glUB/R0PTfzX6Zr8uZqDJrfcRZ0yxihVAR6vHIpLv+6whwsXRbH1dQNHC3EW"
 
-let params = filecoin_signer.deserializeConstructorParams(cbor_base64, "fil/1/paymentchannel")
+let params = filecoin_signer.deserializeConstructorParams(cbor_base64, "fil/2/paymentchannel")
 
 console.log(params);
 ```

--- a/examples/wasm_node/test/test_payment_channel.js
+++ b/examples/wasm_node/test/test_payment_channel.js
@@ -64,7 +64,7 @@ describeCall('createPymtChan', function () {
         Method: 2,
         Nonce: 1,
         Params: serializedParams,
-        To: 't01',
+        To: 'f01',
         Value: '10000000000'
       },
     }
@@ -365,7 +365,7 @@ describeCall('verifyVoucherSignature', function () {
   it('should return true', function () {
     const signedVoucher = "i0MA8gcAAED2AAFEAAGGoACAWEIBayRmYQQCatrELBc2rwfu0jJk0EmVr+eVccDsThtM1ZVzkrC53a6qVgrgFkB8OHoiZSlNmW/nmCU7G2POhEeo2gE=";
     const signerAddress = "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba";
-    
+
     assert(filecoin_signer.verifyVoucherSignature(signedVoucher, signerAddress));
   })
 })

--- a/examples/wasm_node/test/test_payment_channel.js
+++ b/examples/wasm_node/test/test_payment_channel.js
@@ -46,7 +46,7 @@ describeCall('createPymtChan', function () {
       serializedParams = Buffer.from(filecoin_signer.serializeParams(createParams));
 
       let execParams = {
-          CodeCid: 'fil/1/paymentchannel',
+          CodeCid: 'fil/2/paymentchannel',
           ConstructorParams: serializedParams.toString('base64')
       }
 
@@ -106,7 +106,7 @@ describeCall('createPymtChan', function () {
       serializedParams = Buffer.from(filecoin_signer.serializeParams(createParams));
 
       let execParams = {
-          CodeCid: 'fil/1/paymentchannel',
+          CodeCid: 'fil/2/paymentchannel',
           ConstructorParams: serializedParams.toString('base64')
       }
 
@@ -127,7 +127,7 @@ describeCall('createPymtChan', function () {
         Method: 2,
         Nonce: 1,
         Params: serializedParams,
-        To: 't01',
+        To: 'f01',
         Value: '10000000000'
       }
     }

--- a/extras/src/paych.rs
+++ b/extras/src/paych.rs
@@ -169,8 +169,7 @@ pub struct UpdateChannelStateParams {
     pub sv: SignedVoucher,
     #[serde(with = "serde_bytes")]
     pub secret: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub proof: Vec<u8>,
+    // "proof" removed in v2 actros
 }
 
 /// Methods payment channel

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -90,10 +90,10 @@ impl TryFrom<ExecParamsAPI> for ExecParams {
                 .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
         if exec_constructor.code_cid != "fil/1/multisig"
-            && exec_constructor.code_cid != "fil/1/paymentchannel"
+            && exec_constructor.code_cid != "fil/2/paymentchannel"
         {
             return Err(SignerError::GenericString(
-                "Only support `fil/1/multisig` and `fil/1/paymentchannel` code for now."
+                "Only support `fil/1/multisig` and `fil/2/paymentchannel` code for now."
                     .to_string(),
             ));
         }
@@ -420,8 +420,7 @@ pub struct PaymentChannelUpdateStateParams {
     pub sv: String,
     #[serde(alias = "Secret")]
     pub secret: Vec<u8>,
-    #[serde(alias = "Proof")]
-    pub proof: Vec<u8>,
+    // "Proof" removed in v2 specs-actors
 }
 
 impl TryFrom<PaymentChannelUpdateStateParams> for paych::UpdateChannelStateParams {
@@ -435,7 +434,6 @@ impl TryFrom<PaymentChannelUpdateStateParams> for paych::UpdateChannelStateParam
         Ok(paych::UpdateChannelStateParams {
             sv,
             secret: vec![],
-            proof: vec![],
         })
     }
 }
@@ -448,7 +446,6 @@ impl TryInto<PaymentChannelUpdateStateParams> for paych::UpdateChannelStateParam
         Ok(PaymentChannelUpdateStateParams {
             sv: sv_base64,
             secret: self.secret,
-            proof: self.proof,
         })
     }
 }

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -1,7 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
-use extras::{multisig, paych, ExecParams};
 use forest_address::{Address, Network};
 use forest_cid::{multihash::Identity, Cid, Codec};
 use forest_crypto::signature;
@@ -9,6 +8,8 @@ use forest_message::{Message, SignedMessage, UnsignedMessage};
 use forest_vm::Serialized;
 use num_bigint_chainsafe::BigInt;
 use serde::{Deserialize, Serialize, Serializer};
+
+use extras::{multisig, paych, ExecParams};
 
 use crate::error::SignerError;
 use crate::signature::Signature;
@@ -431,10 +432,7 @@ impl TryFrom<PaymentChannelUpdateStateParams> for paych::UpdateChannelStateParam
     ) -> Result<paych::UpdateChannelStateParams, Self::Error> {
         let cbor_sv = base64::decode(params.sv)?;
         let sv: paych::SignedVoucher = forest_encoding::from_slice(cbor_sv.as_ref())?;
-        Ok(paych::UpdateChannelStateParams {
-            sv,
-            secret: vec![],
-        })
+        Ok(paych::UpdateChannelStateParams { sv, secret: vec![] })
     }
 }
 

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -482,7 +482,7 @@ pub fn create_multisig(
     .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let message_params_multisig = ExecParams {
-        code_cid: Cid::new_v1(Codec::Raw, Identity::digest(b"fil/1/multisig")),
+        code_cid: Cid::new_v1(Codec::Raw, Identity::digest(b"fil/2/multisig")),
         constructor_params: serialized_constructor_params,
     };
 
@@ -718,7 +718,7 @@ pub fn create_pymtchan(
             .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let message_params_create_pymtchan = ExecParams {
-        code_cid: Cid::new_v1(Codec::Raw, Identity::digest(b"fil/1/paymentchannel")),
+        code_cid: Cid::new_v1(Codec::Raw, Identity::digest(b"fil/2/paymentchannel")),
         constructor_params: serialized_constructor_params,
     };
 
@@ -727,7 +727,7 @@ pub fn create_pymtchan(
             .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let pch_create_message_api = UnsignedMessageAPI {
-        to: "t01".to_owned(), // INIT_ACTOR_ADDR
+        to: "f01".to_owned(), // INIT_ACTOR_ADDR
         from: from_address,
         nonce,
         value,
@@ -766,7 +766,6 @@ pub fn update_pymtchan(
     let update_payment_channel_params = paych::UpdateChannelStateParams {
         sv,
         secret: vec![],
-        proof: vec![],
     };
 
     let serialized_params = forest_vm::Serialized::serialize::<paych::UpdateChannelStateParams>(
@@ -956,17 +955,17 @@ pub fn deserialize_params(
     let serialized_params = forest_vm::Serialized::new(params_decode);
 
     match actor_type.as_str() {
-        "fil/1/init" => match FromPrimitive::from_u64(method) {
+        "fil/2/init" => match FromPrimitive::from_u64(method) {
             Some(MethodInit::Exec) => {
                 let params = serialized_params.deserialize::<ExecParams>()?;
 
                 Ok(MessageParams::MessageParamsMultisig(params.into()))
             }
             _ => Err(SignerError::GenericString(
-                "Unknown method fo actor 'fil/1/init'.".to_string(),
+                "Unknown method fo actor 'fil/2/init'.".to_string(),
             )),
         },
-        "fil/1/multisig" => match FromPrimitive::from_u64(method) {
+        "fil/2/multisig" => match FromPrimitive::from_u64(method) {
             Some(multisig::MethodMultisig::Propose) => {
                 let params = serialized_params.deserialize::<multisig::ProposeParams>()?;
 
@@ -1001,10 +1000,10 @@ pub fn deserialize_params(
                 ))
             }
             _ => Err(SignerError::GenericString(
-                "Unknown method fo actor 'fil/1/multisig'.".to_string(),
+                "Unknown method fo actor 'fil/2/multisig'.".to_string(),
             )),
         },
-        "fil/1/paymentchannel" => {
+        "fil/2/paymentchannel" => {
             match FromPrimitive::from_u64(method) {
                 Some(paych::MethodsPaych::UpdateChannelState) => {
                     let params =
@@ -1019,7 +1018,7 @@ pub fn deserialize_params(
                     Ok(MessageParams::MessageParamsSerialized("".to_string()))
                 }
                 _ => Err(SignerError::GenericString(
-                    "Unknown method fo actor 'fil/1/paymentchannel'.".to_string(),
+                    "Unknown method fo actor 'fil/2/paymentchannel'.".to_string(),
                 )),
             }
         }
@@ -1043,11 +1042,11 @@ pub fn deserialize_constructor_params(
     let serialized_params = forest_vm::Serialized::new(params_decode);
 
     match code_cid.as_str() {
-        "fil/1/multisig" => {
+        "fil/2/multisig" => {
             let params = serialized_params.deserialize::<multisig::ConstructorParams>()?;
             Ok(MessageParams::ConstructorParamsMultisig(params.into()))
         }
-        "fil/1/paymentchannel" => {
+        "fil/2/paymentchannel" => {
             let params = serialized_params.deserialize::<paych::ConstructorParams>()?;
             Ok(MessageParams::PaymentChannelCreateParams(params.into()))
         }

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -12,6 +12,7 @@ use forest_encoding::blake2b_256;
 use forest_encoding::{from_slice, to_vec};
 use forest_message::SignedMessage;
 use num_bigint_chainsafe::BigInt;
+use num_traits::FromPrimitive;
 use rayon::prelude::*;
 use secp256k1::util::{
     COMPRESSED_PUBLIC_KEY_SIZE, FULL_PUBLIC_KEY_SIZE, SECRET_KEY_SIZE, SIGNATURE_SIZE,
@@ -20,7 +21,6 @@ use secp256k1::{recover, sign, verify, Message, RecoveryId};
 use zx_bip44::BIP44Path;
 
 use extras::{multisig, paych, ExecParams, MethodInit, INIT_ACTOR_ADDR};
-use num_traits::FromPrimitive;
 
 use crate::api::{
     MessageParams, MessageTx, MessageTxAPI, MessageTxNetwork, SignatureAPI, SignedMessageAPI,
@@ -763,10 +763,7 @@ pub fn update_pymtchan(
 
     let sv: paych::SignedVoucher = forest_encoding::from_slice(sv_cbor.as_ref())?;
 
-    let update_payment_channel_params = paych::UpdateChannelStateParams {
-        sv,
-        secret: vec![],
-    };
+    let update_payment_channel_params = paych::UpdateChannelStateParams { sv, secret: vec![] };
 
     let serialized_params = forest_vm::Serialized::serialize::<paych::UpdateChannelStateParams>(
         update_payment_channel_params,
@@ -916,7 +913,7 @@ pub fn create_voucher(
         None => {
             return Err(SignerError::GenericString(
                 "`amount` couldn't be parsed.".to_string(),
-            ))
+            ));
         }
     };
 


### PR DESCRIPTION
 - Changes every occurrence of `fil/1/paymentchannel` to `fil/2/paymentchannel`
 - Removes the `Proof` field of `UpdateChannelStateParameters` (per [this comment](https://github.com/filecoin-project/specs-actors/blob/4baf4d4b44d0ba6d9c78f95d5e20a4c95ee07fd1/actors/builtin/paych/paych_actor.go#L95) in Lotus source)

I've done some basic smoke tests on this and it seems to work.  Edit:  tested Create, Update (single voucher), Update (with multiple vouchers) and Settle.