### PR TITLE
Update reqwest lib because of vuln in dependencies

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -37,7 +37,7 @@ version = "0.2.22"
 features = ["full", "time"]
 
 [dependencies.reqwest]
-version = "0.10.7"
+version = "0.10.8"
 features = ["json", "gzip"]
 
 [dev-dependencies]


### PR DESCRIPTION
`cargo audit` return a vuln message. This should remove the dependency concerned.