### PR TITLE
Updates the tiny-bip39 crate to the last version which includes an im…

### DIFF
--- a/signer-npm/Cargo.toml
+++ b/signer-npm/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-tiny-bip39 = "0.7.3"
+tiny-bip39 = "0.8.0"
 thiserror = "1.0.20"
 serde_json = "1.0.56"
 libsecp256k1 = "0.3.5"

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -42,7 +42,7 @@ forest_encoding = "0.1.2"
 forest_cid = "0.1.1"
 forest_crypto = "0.3.1"
 
-tiny-bip39 = "0.7.3"
+tiny-bip39 = "0.8.0"
 num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.0"}
 
 zx-bip44 = "0.1.0"


### PR DESCRIPTION
The tiny-bip39 crate was updated, the new version is now 0.8.0, and includes this [PR](https://github.com/maciejhirsz/tiny-bip39/pull/22) which avoids leaking sensitive information by zeroising data structures before dropping them.