### PR TITLE
Testing Bignum behavior

### DIFF
--- a/examples/wasm_node/test/test_multisig.js
+++ b/examples/wasm_node/test/test_multisig.js
@@ -36,9 +36,9 @@ describeCall("createMultisig", function() {
       multisig_create.message.value,
       multisig_create.constructor_params.num_approvals_threshold,
       multisig_create.message.nonce,
-      BigInt(multisig_create.constructor_params.unlock_duration),
-      BigInt(multisig_create.constructor_params.start_epoch),
-      BigInt(multisig_create.message.gaslimit),
+      multisig_create.constructor_params.unlock_duration.toString(),
+      multisig_create.constructor_params.start_epoch.toString(),
+      multisig_create.message.gaslimit.toString(),
       multisig_create.message.gasfeecap,
       multisig_create.message.gaspremium
     );
@@ -55,9 +55,9 @@ describeCall("createMultisig", function() {
       multisig_create.message.value,
       multisig_create.constructor_params.num_approvals_threshold,
       multisig_create.message.nonce,
-      BigInt(-1),
-      BigInt(multisig_create.constructor_params.start_epoch),
-      BigInt(multisig_create.message.gaslimit),
+      BigInt(-1).toString(),
+      multisig_create.constructor_params.start_epoch.toString(),
+      multisig_create.message.gaslimit.toString(),
       multisig_create.message.gasfeecap,
       multisig_create.message.gaspremium
     );
@@ -89,24 +89,22 @@ describeCall("createMultisig", function() {
   it("should fail because of bigint", function() {
     const multisig_create = dataTxs.create
 
-    console.log(BigInt("18446744073709551617"))
-
-    let create_multisig_transaction = filecoin_signer.createMultisigWithFee(
-      multisig_create.message.from,
-      multisig_create.constructor_params.signers,
-      multisig_create.message.value,
-      multisig_create.constructor_params.num_approvals_threshold,
-      multisig_create.message.nonce,
-      BigInt(multisig_create.constructor_params.unlock_duration),
-      BigInt(multisig_create.constructor_params.start_epoch),
-      "18446744073709551617",
-      multisig_create.message.gasfeecap,
-      multisig_create.message.gaspremium
+    assert.throws(
+        () => filecoin_signer.createMultisigWithFee(
+          multisig_create.message.from,
+          multisig_create.constructor_params.signers,
+          multisig_create.message.value,
+          multisig_create.constructor_params.num_approvals_threshold,
+          multisig_create.message.nonce,
+          multisig_create.constructor_params.unlock_duration.toString(),
+          multisig_create.constructor_params.start_epoch.toString(),
+          "18446744073709551617",
+          multisig_create.message.gasfeecap,
+          multisig_create.message.gaspremium
+        ),
+        /(number too large to fit in target type)/
     );
-    
-    console.log(create_multisig_transaction)
-    
-    assert(false)
+
   });
   
 })
@@ -121,7 +119,7 @@ describeCall("proposeMultisig", function() {
       multisig_propose.message.from,
       multisig_propose.proposal_params.value,
       multisig_propose.message.nonce,
-      BigInt(multisig_propose.message.gaslimit),
+      multisig_propose.message.gaslimit.toString(),
       multisig_propose.message.gasfeecap,
       multisig_propose.message.gaspremium
     );
@@ -163,7 +161,7 @@ describeCall("approveMultisig", function() {
       multisig_approve.proposal_params.value,
       multisig_approve.message.from,
       multisig_approve.message.nonce,
-      BigInt(multisig_approve.message.gaslimit),
+      multisig_approve.message.gaslimit.toString(),
       multisig_approve.message.gasfeecap,
       multisig_approve.message.gaspremium
     );
@@ -204,7 +202,7 @@ describeCall("cancelMultisig", function() {
       multisig_cancel.proposal_params.value,
       multisig_cancel.message.from,
       multisig_cancel.message.nonce,
-      BigInt(multisig_cancel.message.gaslimit),
+      multisig_cancel.message.gaslimit.toString(),
       multisig_cancel.message.gasfeecap,
       multisig_cancel.message.gaspremium
     );

--- a/examples/wasm_node/test/test_multisig.js
+++ b/examples/wasm_node/test/test_multisig.js
@@ -89,24 +89,21 @@ describeCall("createMultisig", function() {
   it("should fail because of bigint", function() {
     const multisig_create = dataTxs.create
 
-    console.log(BigInt("18446744073709551617"))
-
-    let create_multisig_transaction = filecoin_signer.createMultisigWithFee(
-      multisig_create.message.from,
-      multisig_create.constructor_params.signers,
-      multisig_create.message.value,
-      multisig_create.constructor_params.num_approvals_threshold,
-      multisig_create.message.nonce,
-      BigInt(multisig_create.constructor_params.unlock_duration),
-      BigInt(multisig_create.constructor_params.start_epoch),
-      "18446744073709551617",
-      multisig_create.message.gasfeecap,
-      multisig_create.message.gaspremium
+   assert.throws(
+        () => filecoin_signer.createMultisigWithFee(
+          multisig_create.message.from,
+          multisig_create.constructor_params.signers,
+          multisig_create.message.value,
+          multisig_create.constructor_params.num_approvals_threshold,
+          multisig_create.message.nonce,
+          multisig_create.constructor_params.unlock_duration.toString(),
+          multisig_create.constructor_params.start_epoch.toString(),
+          "18446744073709551617",
+          multisig_create.message.gasfeecap,
+          multisig_create.message.gaspremium
+        ),
+        /(number too large to fit in target type)/
     );
-    
-    console.log(create_multisig_transaction)
-    
-    assert(false)
   });
   
 })

--- a/examples/wasm_node/test/test_multisig.js
+++ b/examples/wasm_node/test/test_multisig.js
@@ -85,6 +85,30 @@ describeCall("createMultisig", function() {
 
     assert(JSON.parse(signature).Signature);
   });
+  
+  it("should fail because of bigint", function() {
+    const multisig_create = dataTxs.create
+
+    console.log(BigInt("18446744073709551617"))
+
+    let create_multisig_transaction = filecoin_signer.createMultisigWithFee(
+      multisig_create.message.from,
+      multisig_create.constructor_params.signers,
+      multisig_create.message.value,
+      multisig_create.constructor_params.num_approvals_threshold,
+      multisig_create.message.nonce,
+      BigInt(multisig_create.constructor_params.unlock_duration),
+      BigInt(multisig_create.constructor_params.start_epoch),
+      "18446744073709551617",
+      multisig_create.message.gasfeecap,
+      multisig_create.message.gaspremium
+    );
+    
+    console.log(create_multisig_transaction)
+    
+    assert(false)
+  });
+  
 })
 
 describeCall("proposeMultisig", function() {

--- a/examples/wasm_node/test/test_multisig.js
+++ b/examples/wasm_node/test/test_multisig.js
@@ -89,22 +89,24 @@ describeCall("createMultisig", function() {
   it("should fail because of bigint", function() {
     const multisig_create = dataTxs.create
 
-    assert.throws(
-        () => filecoin_signer.createMultisigWithFee(
-          multisig_create.message.from,
-          multisig_create.constructor_params.signers,
-          multisig_create.message.value,
-          multisig_create.constructor_params.num_approvals_threshold,
-          multisig_create.message.nonce,
-          multisig_create.constructor_params.unlock_duration.toString(),
-          multisig_create.constructor_params.start_epoch.toString(),
-          "18446744073709551617",
-          multisig_create.message.gasfeecap,
-          multisig_create.message.gaspremium
-        ),
-        /(number too large to fit in target type)/
-    );
+    console.log(BigInt("18446744073709551617"))
 
+    let create_multisig_transaction = filecoin_signer.createMultisigWithFee(
+      multisig_create.message.from,
+      multisig_create.constructor_params.signers,
+      multisig_create.message.value,
+      multisig_create.constructor_params.num_approvals_threshold,
+      multisig_create.message.nonce,
+      BigInt(multisig_create.constructor_params.unlock_duration),
+      BigInt(multisig_create.constructor_params.start_epoch),
+      "18446744073709551617",
+      multisig_create.message.gasfeecap,
+      multisig_create.message.gaspremium
+    );
+    
+    console.log(create_multisig_transaction)
+    
+    assert(false)
   });
   
 })

--- a/examples/wasm_node/test/test_payment_channel.js
+++ b/examples/wasm_node/test/test_payment_channel.js
@@ -40,7 +40,7 @@ describeCall('createPymtChan', function () {
       paymentchannel_create.constructor_params.to,
       paymentchannel_create.message.value,
       paymentchannel_create.message.nonce,
-      BigInt(paymentchannel_create.message.gaslimit),
+      paymentchannel_create.message.gaslimit.toString(),
       paymentchannel_create.message.gasfeecap,
       paymentchannel_create.message.gaspremium
     );
@@ -68,7 +68,7 @@ describeCall('createPymtChan', function () {
       paymentchannel_create.constructor_params.to,
       paymentchannel_create.message.value,
       paymentchannel_create.message.nonce,
-      BigInt(paymentchannel_create.message.gaslimit),
+      paymentchannel_create.message.gaslimit.toString(),
       paymentchannel_create.message.gasfeecap,
       paymentchannel_create.message.gaspremium
     );
@@ -94,7 +94,7 @@ describeCall('updatePymtChan', function () {
       paymentchannel_update.message.from,
       paymentchannel_update.voucher_base64,
       paymentchannel_update.message.nonce,
-      BigInt(paymentchannel_update.message.gaslimit),
+      paymentchannel_update.message.gaslimit.toString(),
       paymentchannel_update.message.gasfeecap,
       paymentchannel_update.message.gaspremium
     );
@@ -125,7 +125,7 @@ describeCall('settlePymtChan', function () {
       paymentchannel_settle.message.to,
       paymentchannel_settle.message.from,
       paymentchannel_settle.message.nonce,
-      BigInt(paymentchannel_settle.message.gaslimit),
+      paymentchannel_settle.message.gaslimit.toString(),
       paymentchannel_settle.message.gasfeecap,
       paymentchannel_settle.message.gaspremium
     );
@@ -153,7 +153,7 @@ describeCall('collectPymtChan', function () {
       paymentchannel_collect.message.to,
       paymentchannel_collect.message.from,
       paymentchannel_collect.message.nonce,
-      BigInt(paymentchannel_collect.message.gaslimit),
+      paymentchannel_collect.message.gaslimit.toString(),
       paymentchannel_collect.message.gasfeecap,
       paymentchannel_collect.message.gaspremium
     );
@@ -178,12 +178,12 @@ describeCall('createVoucher', function () {
     
     const voucher = filecoin_signer.createVoucher(
       voucher_expected.payment_channel_address,
-      BigInt(voucher_expected.time_lock_min),
-      BigInt(voucher_expected.time_lock_max),
+      voucher_expected.time_lock_min.toString(),
+      voucher_expected.time_lock_max.toString(),
       voucher_expected.amount,
-      BigInt(voucher_expected.lane),
-      BigInt(voucher_expected.nonce),
-      BigInt(voucher_expected.min_settle_height),
+      voucher_expected.lane.toString(),
+      voucher_expected.nonce,
+      voucher_expected.min_settle_height.toString(),
     );
 
     assert(voucher);
@@ -201,12 +201,12 @@ describeCall('signVoucher', function () {
 
     const voucher = filecoin_signer.createVoucher(
       voucher_expected.payment_channel_address,
-      BigInt(voucher_expected.time_lock_min),
-      BigInt(voucher_expected.time_lock_max),
+      voucher_expected.time_lock_min.toString(),
+      voucher_expected.time_lock_max.toString(),
       voucher_expected.amount,
-      BigInt(voucher_expected.lane),
-      BigInt(voucher_expected.nonce),
-      BigInt(voucher_expected.min_settle_height),
+      voucher_expected.lane.toString(),
+      voucher_expected.nonce,
+      voucher_expected.min_settle_height.toString(),
     );
     
     const signedVoucher = filecoin_signer.signVoucher(voucher, privateKey);

--- a/extras/Cargo.toml
+++ b/extras/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/Zondax/filecoin-signing-tools"
 description ="Temporary lib used for compatibility with wasm"
 
 [dependencies]
-forest_vm = "0.3.0"
-forest_message = "0.6.0"
-forest_address = "0.3.0"
-forest_encoding = "0.2.0"
-forest_cid = "0.2.0"
-forest_crypto = "0.4.0"
+forest_vm = "0.3.1"
+forest_message = "0.6.1"
+forest_address = "0.3.1"
+forest_encoding = "0.2.1"
+forest_cid = "0.3.0"
+forest_crypto = "0.4.1"
 
 num_bigint = { package = "forest_bigint", version = "0.1.2"}
 clock = { git = "https://github.com/chainsafe/forest", rev="2863f64e40fde88433f9a00be764872f54c2e5ba" }

--- a/signer-npm/src/lib.rs
+++ b/signer-npm/src/lib.rs
@@ -21,6 +21,7 @@ mod ledger_errors;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
@@ -321,14 +322,14 @@ pub fn create_multisig_with_fee(
     value: String,
     required: i32,
     nonce: u32,
-    duration: i64,
-    start_epoch: i64,
-    gas_limit: i64,
+    duration: String,
+    start_epoch: String,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
-
+    
     let addresses_strings_tmp: Result<Vec<String>, _> =
         addresses.into_iter().map(signer_value_to_string).collect();
 
@@ -338,6 +339,13 @@ pub fn create_multisig_with_fee(
             return Err(JsValue::from_str("Error while parsing addresses"));
         }
     };
+    
+    let se = i64::from_str_radix(&start_epoch, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;    
+    let d = i64::from_str_radix(&duration, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let multisig_transaction = filecoin_signer::create_multisig(
         sender_address,
@@ -345,9 +353,9 @@ pub fn create_multisig_with_fee(
         value,
         required as i64,
         nonce as u64,
-        duration,
-        start_epoch,
-        gas_limit,
+        d,
+        se,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -368,11 +376,11 @@ pub fn create_multisig(
     value: String,
     required: i32,
     nonce: u32,
-    duration: i64,
-    start_epoch: i64,
+    duration: String,
+    start_epoch: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
-
+    
     let addresses_strings_tmp: Result<Vec<String>, _> =
         addresses.into_iter().map(signer_value_to_string).collect();
 
@@ -382,6 +390,11 @@ pub fn create_multisig(
             return Err(JsValue::from_str("Error while parsing addresses"));
         }
     };
+    
+    let se = i64::from_str_radix(&start_epoch, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;    
+    let d = i64::from_str_radix(&duration, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let multisig_transaction = filecoin_signer::create_multisig(
         sender_address,
@@ -389,8 +402,8 @@ pub fn create_multisig(
         value,
         required as i64,
         nonce as u64,
-        duration,
-        start_epoch,
+        d,
+        se,
         0,
         "0".to_string(),
         "0".to_string(),
@@ -413,11 +426,14 @@ pub fn propose_multisig_with_fee(
     from_address: String,
     amount: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
+
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let multisig_transaction = filecoin_signer::proposal_multisig_message(
         multisig_address,
@@ -425,7 +441,7 @@ pub fn propose_multisig_with_fee(
         from_address,
         amount,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -479,11 +495,14 @@ pub fn approve_multisig_with_fee(
     amount: String,
     from_address: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
+
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let multisig_transaction = filecoin_signer::approve_multisig_message(
         multisig_address,
@@ -493,7 +512,7 @@ pub fn approve_multisig_with_fee(
         amount,
         from_address,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -551,11 +570,14 @@ pub fn cancel_multisig_with_fee(
     amount: String,
     from_address: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
+
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let multisig_transaction = filecoin_signer::cancel_multisig_message(
         multisig_address,
@@ -565,7 +587,7 @@ pub fn cancel_multisig_with_fee(
         amount,
         from_address,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -619,18 +641,21 @@ pub fn create_pymtchan_with_fee(
     to_address: String,
     amount: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
+
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
     let pch_transaction = filecoin_signer::create_pymtchan(
         from_address,
         to_address,
         amount,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -673,17 +698,20 @@ pub fn settle_pymtchan_with_fee(
     pch_address: String,
     from_address: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
 
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
     let pch_transaction = filecoin_signer::settle_pymtchan(
         pch_address,
         from_address,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -724,17 +752,20 @@ pub fn collect_pymtchan_with_fee(
     pch_address: String,
     from_address: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
 
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
     let pch_transaction = filecoin_signer::collect_pymtchan(
         pch_address,
         from_address,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -776,7 +807,7 @@ pub fn update_pymtchan_with_fee(
     from_address: String,
     signed_voucher: String,
     nonce: u32,
-    gas_limit: i64,
+    gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
@@ -784,12 +815,15 @@ pub fn update_pymtchan_with_fee(
 
     // TODO: verify if `pch_address` is an actor address. Not needed but good improvement.
 
+    let gl = i64::from_str_radix(&gas_limit, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
     let pch_transaction = filecoin_signer::update_pymtchan(
         pch_address,
         from_address,
         signed_voucher,
         nonce as u64,
-        gas_limit,
+        gl,
         gas_fee_cap,
         gas_premium,
     )
@@ -847,23 +881,35 @@ pub fn sign_voucher(voucher: String, private_key_js: JsValue) -> Result<JsValue,
 #[wasm_bindgen(js_name = createVoucher)]
 pub fn create_voucher(
     payment_channel_address: String,
-    time_lock_min: i64,
-    time_lock_max: i64,
+    time_lock_min: String,
+    time_lock_max: String,
     amount: String,
-    lane: u64,
-    nonce: u64,
-    min_settle_height: i64,
+    lane: String,
+    nonce: u32,
+    min_settle_height: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
+    
+    let tlmin = i64::from_str_radix(&time_lock_min, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+    let tlmax = i64::from_str_radix(&time_lock_max, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
+    let l = u64::from_str_radix(&lane, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
+    let msh = i64::from_str_radix(&min_settle_height, 10)
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
+
 
     let voucher = filecoin_signer::create_voucher(
         payment_channel_address,
-        time_lock_min,
-        time_lock_max,
+        tlmin,
+        tlmax,
         amount,
-        lane,
-        nonce,
-        min_settle_height,
+        l,
+        nonce as u64,
+        msh,
     )
     .map_err(|e| {
         JsValue::from_str(format!("Error creating payment channel voucher: {}", e).as_str())

--- a/signer-npm/src/lib.rs
+++ b/signer-npm/src/lib.rs
@@ -21,7 +21,6 @@ mod ledger_errors;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then
@@ -329,7 +328,7 @@ pub fn create_multisig_with_fee(
     gas_premium: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
-    
+
     let addresses_strings_tmp: Result<Vec<String>, _> =
         addresses.into_iter().map(signer_value_to_string).collect();
 
@@ -339,9 +338,9 @@ pub fn create_multisig_with_fee(
             return Err(JsValue::from_str("Error while parsing addresses"));
         }
     };
-    
+
     let se = i64::from_str_radix(&start_epoch, 10)
-        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;    
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
     let d = i64::from_str_radix(&duration, 10)
         .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
     let gl = i64::from_str_radix(&gas_limit, 10)
@@ -380,7 +379,7 @@ pub fn create_multisig(
     start_epoch: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
-    
+
     let addresses_strings_tmp: Result<Vec<String>, _> =
         addresses.into_iter().map(signer_value_to_string).collect();
 
@@ -390,9 +389,9 @@ pub fn create_multisig(
             return Err(JsValue::from_str("Error while parsing addresses"));
         }
     };
-    
+
     let se = i64::from_str_radix(&start_epoch, 10)
-        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;    
+        .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
     let d = i64::from_str_radix(&duration, 10)
         .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
 
@@ -889,7 +888,7 @@ pub fn create_voucher(
     min_settle_height: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
-    
+
     let tlmin = i64::from_str_radix(&time_lock_min, 10)
         .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
     let tlmax = i64::from_str_radix(&time_lock_max, 10)
@@ -900,7 +899,6 @@ pub fn create_voucher(
 
     let msh = i64::from_str_radix(&min_settle_height, 10)
         .map_err(|e| JsValue::from(format!("Error converting to i64: {}", e)))?;
-
 
     let voucher = filecoin_signer::create_voucher(
         payment_channel_address,

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -35,12 +35,12 @@ arbitrary = { optional = true, features = ["derive"], version = "" }
 ffi-support = { optional = true, version = "0.4" }
 
 
-forest_vm = "0.3.0"
-forest_message = "0.6.0"
-forest_address = "0.3.0"
-forest_encoding = "0.2.0"
-forest_cid = "0.2.0"
-forest_crypto = "0.4.0"
+forest_vm = "0.3.1"
+forest_message = "0.6.1"
+forest_address = "0.3.1"
+forest_encoding = "0.2.1"
+forest_cid = "0.3.0"
+forest_crypto = "0.4.1"
 
 tiny-bip39 = "0.8.0"
 num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.2"}

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
 use forest_address::{Address, Network};
-use forest_cid::{multihash::MultihashDigest, Cid, Code::Identity, Codec};
+use forest_cid::{multihash::MultihashDigest, Cid, Code::Identity};
 use forest_crypto::signature;
 use forest_message::{Message, SignedMessage, UnsignedMessage};
 use forest_vm::Serialized;
@@ -105,7 +105,7 @@ impl TryFrom<ExecParamsAPI> for ExecParams {
 
         Ok(ExecParams {
             code_cid: Cid::new_v1(
-                Codec::Raw,
+                forest_cid::RAW,
                 Identity.digest(exec_constructor.code_cid.as_bytes()),
             ),
             constructor_params: forest_vm::Serialized::new(serialized_constructor_multisig_params),

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use bip39::{Language, MnemonicType, Seed};
 use bls_signatures::Serialize;
 use forest_address::{Address, BLSPublicKey, Network, Protocol};
-use forest_cid::{multihash::MultihashDigest, Cid, Code::Blake2b256, Code::Identity, Codec};
+use forest_cid::{multihash::MultihashDigest, Cid, Code::Blake2b256, Code::Identity};
 use forest_encoding::blake2b_256;
 use forest_encoding::{from_slice, to_vec};
 use forest_message::SignedMessage;
@@ -568,7 +568,7 @@ pub fn create_multisig(
     .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let message_params_multisig = ExecParams {
-        code_cid: Cid::new_v1(Codec::Raw, Identity.digest(b"fil/2/multisig")),
+        code_cid: Cid::new_v1(forest_cid::RAW, Identity.digest(b"fil/2/multisig")),
         constructor_params: serialized_constructor_params,
     };
 
@@ -807,7 +807,7 @@ pub fn create_pymtchan(
             .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let message_params_create_pymtchan = ExecParams {
-        code_cid: Cid::new_v1(Codec::Raw, Identity.digest(b"fil/2/paymentchannel")),
+        code_cid: Cid::new_v1(forest_cid::RAW, Identity.digest(b"fil/2/paymentchannel")),
         constructor_params: serialized_constructor_params,
     };
 
@@ -1211,7 +1211,7 @@ pub fn get_cid(signed_message_api: SignedMessageAPI) -> Result<String, SignerErr
     let signed_message = SignedMessage::try_from(&signed_message_api)?;
     let cbor_signed_message = to_vec(&signed_message)?;
 
-    let cid = Cid::new_from_cbor(&cbor_signed_message, Blake2b256);
+    let cid = forest_cid::new_from_cbor(&cbor_signed_message, Blake2b256);
 
     Ok(cid.to_string())
 }


### PR DESCRIPTION
See https://github.com/Zondax/filecoin-signing-tools/issues/237

For now a number bigger than `"18446744073709551617"` will result in returning 0.

It does it silently so it could b easy to miss it. Maybe throwing an error for when it is bigger than max i64 would avoid future issue.