### PR TITLE
Re-order package.json exports for Webpack 5 browser usage

### DIFF
--- a/signer-npm/package-signer.json
+++ b/signer-npm/package-signer.json
@@ -30,10 +30,10 @@
   "main": "./browser/filecoin_signer_wasm.js",
   "exports": {
     ".": {
+      "browser": "./browser/filecoin_signer_wasm.js",
       "node": "./nodejs/filecoin_signer_wasm.js",
       "require": "./nodejs/filecoin_signer_wasm.js",
-      "import": "./nodejs/filecoin_signer_wasm.js",
-      "browser": "./browser/filecoin_signer_wasm.js"
+      "import": "./nodejs/filecoin_signer_wasm.js"
     },
     "./js": "./js/src/index.js",
     "./utils": "./js/src/utils/index.js"


### PR DESCRIPTION
The export conditions are evaluated and the first that
matches will be used. The ./nodejs/filecoin_signer_wasm.js
gets matched for "import" or "require", so the the "browser"
condition with ./browser/filecoin_signer_wasm.js never gets
matched. Webpack 4 automatically installs polyfills for Node.js
libraries but Webpack 5 won't.

https://webpack.js.org/guides/package-exports/

Re-ordering the export conditions so that the browser condition
appears first allows this library to be used with Webpack 5
for browser builds without polyfills.