### PR TITLE
feat: Use same signing payload as Lotus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ endif
 build_npm:
 	rm -rf signer-npm/pkg/
 	wasm-pack build --no-typescript --target nodejs --out-dir pkg/nodejs  signer-npm/
+	# Adjust for weird `env` dependency
+	sed -i.bak "s/require('env')/\{now: () => 1\}/g" signer-npm/pkg/nodejs/filecoin_signer_wasm.js
+	rm signer-npm/pkg/nodejs/filecoin_signer_wasm.js.bak
 	wasm-pack build --no-typescript --target browser --out-dir pkg/browser signer-npm/
 	# For the pure js we need the node_modules folder when using `yarn link`
 	cd signer-npm/js && yarn install && yarn lint

--- a/extras/Cargo.toml
+++ b/extras/Cargo.toml
@@ -11,8 +11,8 @@ description ="Temporary lib used for compatibility with wasm"
 forest_vm = "0.3.0"
 forest_message = "0.6.0"
 forest_address = "0.3.0"
-forest_encoding = "0.2.0"
-forest_cid = "0.2.0"
+forest_encoding = "0.2.1"
+forest_cid = "0.3.0"
 forest_crypto = "0.4.0"
 
 num_bigint = { package = "forest_bigint", version = "0.1.2"}

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -38,8 +38,8 @@ ffi-support = { optional = true, version = "0.4" }
 forest_vm = "0.3.0"
 forest_message = "0.6.0"
 forest_address = "0.3.0"
-forest_encoding = "0.2.0"
-forest_cid = "0.2.0"
+forest_encoding = "0.2.1"
+forest_cid = "0.3.0"
 forest_crypto = "0.4.0"
 
 tiny-bip39 = "0.8.0"

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -360,7 +360,7 @@ pub struct ChangeNumApprovalsThresholdMultisigParams {
 }
 
 impl TryFrom<ChangeNumApprovalsThresholdMultisigParams>
-for multisig::ChangeNumApprovalsThresholdParams
+    for multisig::ChangeNumApprovalsThresholdParams
 {
     type Error = SignerError;
 
@@ -374,7 +374,7 @@ for multisig::ChangeNumApprovalsThresholdParams
 }
 
 impl Into<ChangeNumApprovalsThresholdMultisigParams>
-for multisig::ChangeNumApprovalsThresholdParams
+    for multisig::ChangeNumApprovalsThresholdParams
 {
     fn into(self) -> ChangeNumApprovalsThresholdMultisigParams {
         ChangeNumApprovalsThresholdMultisigParams {
@@ -473,8 +473,8 @@ impl From<&SpecsActorsCryptoSignature> for SpecsActorsCryptoSignature {
 
 impl Serialize for SpecsActorsCryptoSignature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         let mut v = Vec::<u8>::new();
         v.push(self.typ);
@@ -567,7 +567,7 @@ impl MessageParams {
                 forest_vm::Serialized::serialize::<multisig::ChangeNumApprovalsThresholdParams>(
                     params,
                 )
-                    .map_err(|err| SignerError::GenericString(err.to_string()))?
+                .map_err(|err| SignerError::GenericString(err.to_string()))?
             }
             MessageParams::PaymentChannelCreateParams(pymtchan_create_params) => {
                 let params = paych::ConstructorParams::try_from(pymtchan_create_params)?;
@@ -710,15 +710,15 @@ mod serde_base64_vector {
     use serde::{self, Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(v: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&base64::encode(v))
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         base64::decode(s).map_err(serde::de::Error::custom)

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
 use forest_address::{Address, Network};
-use forest_cid::{multihash::MultihashDigest, Cid, Code::Identity, Codec};
+use forest_cid::{multihash::MultihashDigest, Cid, Code::Identity};
 use forest_crypto::signature;
 use forest_message::{Message, SignedMessage, UnsignedMessage};
 use forest_vm::Serialized;
@@ -105,7 +105,7 @@ impl TryFrom<ExecParamsAPI> for ExecParams {
 
         Ok(ExecParams {
             code_cid: Cid::new_v1(
-                Codec::Raw,
+                forest_cid::RAW,
                 Identity.digest(exec_constructor.code_cid.as_bytes()),
             ),
             constructor_params: forest_vm::Serialized::new(serialized_constructor_multisig_params),
@@ -360,7 +360,7 @@ pub struct ChangeNumApprovalsThresholdMultisigParams {
 }
 
 impl TryFrom<ChangeNumApprovalsThresholdMultisigParams>
-    for multisig::ChangeNumApprovalsThresholdParams
+for multisig::ChangeNumApprovalsThresholdParams
 {
     type Error = SignerError;
 
@@ -374,7 +374,7 @@ impl TryFrom<ChangeNumApprovalsThresholdMultisigParams>
 }
 
 impl Into<ChangeNumApprovalsThresholdMultisigParams>
-    for multisig::ChangeNumApprovalsThresholdParams
+for multisig::ChangeNumApprovalsThresholdParams
 {
     fn into(self) -> ChangeNumApprovalsThresholdMultisigParams {
         ChangeNumApprovalsThresholdMultisigParams {
@@ -473,8 +473,8 @@ impl From<&SpecsActorsCryptoSignature> for SpecsActorsCryptoSignature {
 
 impl Serialize for SpecsActorsCryptoSignature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         let mut v = Vec::<u8>::new();
         v.push(self.typ);
@@ -567,7 +567,7 @@ impl MessageParams {
                 forest_vm::Serialized::serialize::<multisig::ChangeNumApprovalsThresholdParams>(
                     params,
                 )
-                .map_err(|err| SignerError::GenericString(err.to_string()))?
+                    .map_err(|err| SignerError::GenericString(err.to_string()))?
             }
             MessageParams::PaymentChannelCreateParams(pymtchan_create_params) => {
                 let params = paych::ConstructorParams::try_from(pymtchan_create_params)?;
@@ -710,15 +710,15 @@ mod serde_base64_vector {
     use serde::{self, Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(v: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where
+            S: Serializer,
     {
         serializer.serialize_str(&base64::encode(v))
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         base64::decode(s).map_err(serde::de::Error::custom)

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -556,7 +556,7 @@ pub fn create_multisig(
     let serialized_constructor_params = forest_vm::Serialized::serialize::<
         multisig::ConstructorParams,
     >(constructor_params_multisig)
-        .map_err(|err| SignerError::GenericString(err.to_string()))?;
+    .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     let message_params_multisig = ExecParams {
         code_cid: Cid::new_v1(forest_cid::RAW, Identity.digest(b"fil/2/multisig")),
@@ -851,7 +851,7 @@ pub fn update_pymtchan(
     let serialized_params = forest_vm::Serialized::serialize::<paych::UpdateChannelStateParams>(
         update_payment_channel_params,
     )
-        .map_err(|err| SignerError::GenericString(err.to_string()))?;
+    .map_err(|err| SignerError::GenericString(err.to_string()))?;
 
     // TODO:  don't hardcode gas limit and gas price; use a gas estimator!
     let pch_update_message_api = UnsignedMessageAPI {

--- a/signer/tests/lib_test.rs
+++ b/signer/tests/lib_test.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 use filecoin_signer::api::{MessageTxAPI, SignedMessageAPI, UnsignedMessageAPI};
 use filecoin_signer::signature::{Signature, SignatureBLS};
 use filecoin_signer::*;
-use forest_cid::{Code::Blake2b256};
+use forest_cid::Code::Blake2b256;
 
 mod common;
 
@@ -427,7 +427,7 @@ fn payment_channel_creation_bls_signing() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let pch_create_message_expected: UnsignedMessageAPI =
         serde_json::from_value(tc_creation_bls["message"].to_owned()).unwrap();
@@ -513,7 +513,7 @@ fn payment_channel_update() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let pch_update_message_unsigned_expected: UnsignedMessageAPI =
         serde_json::from_value(tc_update_secp256k1["message"].to_owned())
@@ -568,7 +568,7 @@ fn payment_channel_settle() {
             .to_string()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let pch_settle_message_unsigned_expected: UnsignedMessageAPI =
         serde_json::from_value(tc_settle_secp256k1["message"].to_owned())
@@ -624,7 +624,7 @@ fn payment_channel_collect() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let pch_collect_message_unsigned_expected: UnsignedMessageAPI =
         serde_json::from_value(tc_collect_secp256k1["message"].to_owned())
@@ -669,7 +669,7 @@ fn test_sign_voucher() {
         voucher_value["nonce"].as_u64().unwrap(),
         voucher_value["min_settle_height"].as_i64().unwrap(),
     )
-        .unwrap();
+    .unwrap();
 
     let signed_voucher = sign_voucher(voucher, &extended_key.private_key).unwrap();
 
@@ -726,7 +726,7 @@ fn support_multisig_create() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let multisig_create_message_expected: UnsignedMessageAPI =
         serde_json::from_value(test_value["create"]["message"].to_owned()).unwrap();
@@ -778,7 +778,7 @@ fn support_multisig_propose_message() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let multisig_proposal_message_expected: UnsignedMessageAPI =
         serde_json::from_value(test_value["propose"]["message"].to_owned()).unwrap();
@@ -834,7 +834,7 @@ fn support_multisig_approve_message() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let multisig_approval_message_expected: UnsignedMessageAPI =
         serde_json::from_value(test_value["approve"]["message"].to_owned()).unwrap();
@@ -890,7 +890,7 @@ fn support_multisig_cancel_message() {
             .unwrap()
             .to_string(),
     )
-        .unwrap();
+    .unwrap();
 
     let multisig_cancel_message_expected: UnsignedMessageAPI =
         serde_json::from_value(test_value["cancel"]["message"].to_owned()).unwrap();


### PR DESCRIPTION
Current upstream implementation uses CBOR-encoded message as a signed payload. For quite a long time Lotus [actually signs CID of a message](https://github.com/filecoin-project/lotus/blob/master/node/impl/full/wallet.go#L59). This PR brings signing functionality in alignment with Lotus.

To check:
Lotus:
- use private key, for example `7b2254797065223a22626c73222c22507269766174654b6579223a22385967422b36526369365759684c775965625a5678666548596a39337655624c6d573244423871467979413d227d`
- import it to Lotus instance, this should give `f3u6d4jv6eythwo5bwicl4ygzvt6xvqzi4bbgrheykauqhdj6yxiws3lyntvmjtnerlfes3obfigf3we33pxnq` address,
- sign the following message with Lotus using the script: https://gist.github.com/ukstv/488ac73d1f4d878596a21287cd47df41#file-lotus-js
- Lotus responds with signature `g0YQybhWC2HXB5b0rG11qZ9pk+Pl5VgZp/ulJCdT9v262D4bAJpU/EFab3fniMngDrJUFbxw1O7rgs8Gv7UHbRNUn2xFrEmdkIeca2J37H65wSnFEDPy2iwS0eZxtEoW`

filecoin-signing-tools:
- put [gist](https://gist.github.com/ukstv/488ac73d1f4d878596a21287cd47df41#file-fst-js) to a root folder of the package, it will sign the same message with the same BLS private key,
- returned signature should be the same.

As per the current upstream, the signatures differ. This PR makes them same.