### PR TITLE
Native JS BLS helpers

### DIFF
--- a/signer-npm/js/src/index.js
+++ b/signer-npm/js/src/index.js
@@ -8,6 +8,7 @@ const lowercaseKeys = require("lowercase-keys");
 
 const ExtendedKey = require("./extendedkey");
 const {
+  getCID,
   getDigest,
   getCoinTypeFromPath,
   addressAsBytes,
@@ -440,4 +441,6 @@ module.exports = {
   verifySignature,
   addressAsBytes,
   bytesToAddress,
+  getDigest,
+  getCID,
 };

--- a/signer-npm/js/src/utils.js
+++ b/signer-npm/js/src/utils.js
@@ -82,7 +82,15 @@ function addressAsBytes(address) {
       }
       break;
     case ProtocolIndicator.BLS:
-      throw new ProtocolNotSupported("BLS");
+      address_decoded = base32Decode(address.slice(2).toUpperCase(), "RFC4648");
+
+      payload = address_decoded.slice(0, -4);
+      checksum = Buffer.from(address_decoded.slice(-4));
+
+      if (payload.byteLength !== 48) {
+        throw new InvalidPayloadLength();
+      }
+      break;
     default:
       throw new UnknownProtocolIndicator();
   }


### PR DESCRIPTION
The signing tools library does not support parsing BLS addresses. 

This prevents:
- users from sending FIL to a BLS address from an secp256 address, even though the library can handle this signature just fine
- users from building on top of the serialization functionality to add their own BLS signatures

I also exported `getCID` and `getDigest` for the second reason.

For context, I am adding javascript BLS signatures for our own use using https://github.com/paulmillr/noble-bls12-381. I'm happy to contribute that functionality back to this library if there is interest. It would change the API slightly as the current bls operations are synchronous and the noble library functions asynchronously