### PR TITLE
Deserialize V1 multisig constructor parameters

### DIFF
--- a/extras/src/multisig.rs
+++ b/extras/src/multisig.rs
@@ -32,6 +32,14 @@ pub struct ConstructorParams {
     pub start_epoch: ChainEpoch,
 }
 
+/// Constructor parameters for multisig actor V1 (deprecated)
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ConstructorParamsV1 {
+    pub signers: Vec<Address>,
+    pub num_approvals_threshold: i64,
+    pub unlock_duration: ChainEpoch,
+}
+
 /// Propose method call parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]
 pub struct ProposeParams {

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1182,7 +1182,8 @@ pub fn deserialize_constructor_params(
             Ok(MessageParams::PaymentChannelCreateParams(params.into()))
         }
         "fil/1/multisig" => {
-            let deprecated_multisig_params = serialized_params.deserialize::<multisig::ConstructorParamsV1>()?;
+            let deprecated_multisig_params =
+                serialized_params.deserialize::<multisig::ConstructorParamsV1>()?;
             let params = multisig::ConstructorParams {
                 signers: deprecated_multisig_params.signers,
                 num_approvals_threshold: deprecated_multisig_params.num_approvals_threshold,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -1181,6 +1181,16 @@ pub fn deserialize_constructor_params(
             let params = serialized_params.deserialize::<paych::ConstructorParams>()?;
             Ok(MessageParams::PaymentChannelCreateParams(params.into()))
         }
+        "fil/1/multisig" => {
+            let deprecated_multisig_params = serialized_params.deserialize::<multisig::ConstructorParamsV1>()?;
+            let params = multisig::ConstructorParams {
+                signers: deprecated_multisig_params.signers,
+                num_approvals_threshold: deprecated_multisig_params.num_approvals_threshold,
+                unlock_duration: deprecated_multisig_params.unlock_duration,
+                start_epoch: 0,
+            };
+            Ok(MessageParams::ConstructorParamsMultisig(params.into()))
+        }
         _ => Err(SignerError::GenericString(
             "Code CID not supported.".to_string(),
         )),

--- a/signer/tests/lib_test.rs
+++ b/signer/tests/lib_test.rs
@@ -9,7 +9,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rayon::prelude::*;
 
-use filecoin_signer::api::{MessageTxAPI, SignedMessageAPI, UnsignedMessageAPI, MessageParams};
+use filecoin_signer::api::{MessageParams, MessageTxAPI, SignedMessageAPI, UnsignedMessageAPI};
 use filecoin_signer::signature::{Signature, SignatureBLS};
 use filecoin_signer::*;
 
@@ -946,12 +946,22 @@ fn test_get_cid() {
 #[test]
 fn test_multisig_v1_deserialize() {
     let expected_params = multisig::ConstructorParams {
-        signers: vec![Address::from_bytes(&hex::decode("01D75AB2B78BB2FEB1CF86B1412E96916D805B40C3").unwrap()).unwrap()],
+        signers: vec![Address::from_bytes(
+            &hex::decode("01D75AB2B78BB2FEB1CF86B1412E96916D805B40C3").unwrap(),
+        )
+        .unwrap()],
         num_approvals_threshold: 1,
         unlock_duration: 0,
         start_epoch: 0,
     };
-    let params = deserialize_constructor_params("g4FVAddasreLsv6xz4axQS6WkW2AW0DDAQA=".to_string(), "fil/1/multisig".to_string()).unwrap();
+    let params = deserialize_constructor_params(
+        "g4FVAddasreLsv6xz4axQS6WkW2AW0DDAQA=".to_string(),
+        "fil/1/multisig".to_string(),
+    )
+    .unwrap();
 
-    assert_eq!(params, MessageParams::ConstructorParamsMultisig(expected_params.into()));
+    assert_eq!(
+        params,
+        MessageParams::ConstructorParamsMultisig(expected_params.into())
+    );
 }

--- a/signer/tests/lib_test.rs
+++ b/signer/tests/lib_test.rs
@@ -9,9 +9,11 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rayon::prelude::*;
 
-use filecoin_signer::api::{MessageTxAPI, SignedMessageAPI, UnsignedMessageAPI};
+use filecoin_signer::api::{MessageTxAPI, SignedMessageAPI, UnsignedMessageAPI, MessageParams};
 use filecoin_signer::signature::{Signature, SignatureBLS};
 use filecoin_signer::*;
+
+use extras::multisig;
 
 mod common;
 
@@ -939,4 +941,17 @@ fn test_get_cid() {
     let cid = get_cid(message_api).unwrap();
 
     assert_eq!(cid, expected_cid);
+}
+
+#[test]
+fn test_multisig_v1_deserialize() {
+    let expected_params = multisig::ConstructorParams {
+        signers: vec![Address::from_bytes(&hex::decode("01D75AB2B78BB2FEB1CF86B1412E96916D805B40C3").unwrap()).unwrap()],
+        num_approvals_threshold: 1,
+        unlock_duration: 0,
+        start_epoch: 0,
+    };
+    let params = deserialize_constructor_params("g4FVAddasreLsv6xz4axQS6WkW2AW0DDAQA=".to_string(), "fil/1/multisig".to_string()).unwrap();
+
+    assert_eq!(params, MessageParams::ConstructorParamsMultisig(expected_params.into()));
 }


### PR DESCRIPTION
closes #355 

This PR add support for the V1 multisig constructor parameter. Multisig V1 was deprecated in testnet but still appeared in mainnet.