### PR TITLE
adding support for parsing BLS address

### DIFF
--- a/signer-npm/js/src/utils.js
+++ b/signer-npm/js/src/utils.js
@@ -80,7 +80,15 @@ function addressAsBytes(address) {
       }
       break
     case ProtocolIndicator.BLS:
-      throw new ProtocolNotSupported('BLS')
+      address_decoded = base32Decode(address.slice(2).toUpperCase(), 'RFC4648')
+
+      payload = address_decoded.slice(0, -4)
+      checksum = Buffer.from(address_decoded.slice(-4))
+
+      if (payload.byteLength !== 48) {
+        throw new InvalidPayloadLength()
+      }
+      break
     default:
       throw new UnknownProtocolIndicator()
   }
@@ -112,7 +120,10 @@ function bytesToAddress(payload, testnet) {
       }
       break
     case ProtocolIndicator.BLS:
-      throw new ProtocolNotSupported('BLS')
+      if (payload.slice(1).length !== 48) {
+        throw new InvalidPayloadLength()
+      }
+      break
     default:
       throw new UnknownProtocolIndicator()
   }


### PR DESCRIPTION
It should support parsing BLS address.

NOTE: should be reviewed carefuly. If the address is wrongly parsed it could send funds to an invalid `to` address.

Maybe more specific testing could be added.