### PR TITLE
Allow specifying method and serialized parameters for multisig proposal

### DIFF
--- a/docs/rs_native_api.md
+++ b/docs/rs_native_api.md
@@ -379,6 +379,11 @@ Arguments:
 * **from_address**: A string address;
 * **amount**: Amount of the transaction;
 * **nonce**: Nonce of the message;
+* **gas_limit**: The gas limit
+* **gas_fee_cap**: The gas fee cap
+* **gas_premium**: The gas premium
+* **proposal_method**: The proposal method
+* **proposal_serialized_params**: The proposal parameters serialized
 
 ```rust
 use signer::proposal_multisig_message;
@@ -389,6 +394,11 @@ let result = proposal_multisig_message(
     "t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba".to_string(),
     "1000".to_string(),
     1,
+    250,
+    250,
+    250,
+    0,
+    "".to_string(),
 )
 .unwrap();
 

--- a/examples/wasm_node/test/test_multisig.js
+++ b/examples/wasm_node/test/test_multisig.js
@@ -124,6 +124,8 @@ describeCall('proposeMultisig', function() {
       multisig_propose.message.gaslimit.toString(),
       multisig_propose.message.gasfeecap,
       multisig_propose.message.gaspremium,
+      multisig_propose.proposal_params.method,
+      multisig_propose.proposal_params.params,
     )
 
     assert.deepStrictEqual(multisig_propose.message, propose_multisig_transaction)

--- a/signer-npm/src/lib.rs
+++ b/signer-npm/src/lib.rs
@@ -423,6 +423,8 @@ pub fn propose_multisig_with_fee(
     gas_limit: String,
     gas_fee_cap: String,
     gas_premium: String,
+    method: u32,
+    params: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
 
@@ -438,6 +440,8 @@ pub fn propose_multisig_with_fee(
         gl,
         gas_fee_cap,
         gas_premium,
+        method as u64,
+        params,
     )
     .map_err(|e| {
         JsValue::from_str(format!("Error porposing multisig transaction: {}", e).as_str())
@@ -456,6 +460,8 @@ pub fn propose_multisig(
     from_address: String,
     amount: String,
     nonce: u32,
+    method: u32,
+    params: String,
 ) -> Result<JsValue, JsValue> {
     set_panic_hook();
 
@@ -468,6 +474,8 @@ pub fn propose_multisig(
         0,
         "0".to_string(),
         "0".to_string(),
+        method as u64,
+        params,
     )
     .map_err(|e| {
         JsValue::from_str(format!("Error porposing multisig transaction: {}", e).as_str())

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -630,6 +630,11 @@ pub fn create_multisig(
 /// * `from_address` - A string address
 /// * `amount` - Amount of the transaction
 /// * `nonce` - Nonce of the message
+/// * `gas_limit` - The gas limit
+/// * `gas_fee_cap` - The gas fee cap
+/// * `gas_premium` - The gas premium
+/// * `proposal_method` - The proposal method
+/// * `proposal_serialized_params` - The proposal parameters serialized
 ///
 #[allow(clippy::too_many_arguments)]
 pub fn proposal_multisig_message(
@@ -641,12 +646,14 @@ pub fn proposal_multisig_message(
     gas_limit: i64,
     gas_fee_cap: String,
     gas_premium: String,
+    proposal_method: u64,
+    proposal_serialized_params: String,
 ) -> Result<UnsignedMessageAPI, SignerError> {
     let propose_params_multisig = multisig::ProposeParams {
         to: Address::from_str(&to_address)?,
         value: BigInt::from_str(&amount)?,
-        method: 0,
-        params: forest_vm::Serialized::new(Vec::new()),
+        method: proposal_method,
+        params: forest_vm::Serialized::new(base64::decode(proposal_serialized_params)?),
     };
 
     let params =

--- a/signer/tests/lib_test.rs
+++ b/signer/tests/lib_test.rs
@@ -784,6 +784,13 @@ fn support_multisig_propose_message() {
             .as_str()
             .unwrap()
             .to_string(),
+        test_value["propose"]["proposal_params"]["method"]
+            .as_u64()
+            .unwrap(),
+        test_value["propose"]["proposal_params"]["params"]
+            .as_str()
+            .unwrap()
+            .to_string(),
     )
     .unwrap();
 


### PR DESCRIPTION
closes #351

This PR allows creating other kinds of multisig proposal transaction by specifying in the argument the method and serialized params.

This breaks the current way of creating multisig proposal transaction.  