### PR TITLE
Feature: new multisig RPCs

### DIFF
--- a/service/fcservice-postman-collection.json
+++ b/service/fcservice-postman-collection.json
@@ -66,7 +66,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"key_derive\",\n    \"params\": [\n        \"robust creek govern marriage super design group accuse soccer romance shrug blame broom render apart glass expire mom enforce six range gate dose organ\",\n        \"m/44'/461'/0/0/0\",\n        \"\",\n        \"en\"\n    ]\n}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"key_derive\",\n    \"params\": [\n        \"equip will roof matter pink blind book anxiety banner elbow sun young\",\n        \"m/44'/461'/0/0/0\",\n        \"\",\n        \"en\"\n    ]\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -195,7 +195,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"1\",\n    \"method\": \"sign_transaction\",\n    \"params\": [\n        {\n            \"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\",\n            \"from\": \"f1jejt4mukbw4oh5c2mt3yyvpdif7l55lich5qo3i\",\n            \"nonce\": 1,\n            \"value\": \"100000\",\n            \"gasprice\": \"2500\",\n            \"gasFeeCap\": \"2500\",\n            \"gasPremium\": \"2500\",\n            \"gaslimit\": 25000,\n            \"method\": 0,\n            \"params\": \"\"\n        },\n        \"PYGdWyC0OOMtAS4ePlOA6XmEZbZcJfw9Bo12X6zVSuo=\"\n    ]\n}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"sign_transaction\",\n    \"params\": [\n        {\n            \"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\",\n            \"from\": \"t1b4zd6ryj5dsnwda5jtjxj6ptkia5e35s52ox7ka\",\n            \"nonce\": 1,\n            \"value\": \"100000\",\n            \"gasprice\": \"2500\",\n            \"gasFeeCap\": \"2500\",\n            \"gasPremium\": \"2500\",\n            \"gaslimit\": 25000,\n            \"method\": 0,\n            \"params\": \"\"\n        },\n        \"f15716d3b003b304b8055d9cc62e6b9c869d56cc930c3858d4d7c31f5f53f14a\"\n    ]\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -436,5 +436,6 @@
 			},
 			"response": []
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/service/fcservice-postman-collection.json
+++ b/service/fcservice-postman-collection.json
@@ -23,10 +23,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"key_generate_mnemonic\", \"params\": []}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"key_generate_mnemonic\",\n    \"params\": []\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
 						}
 					}
 				},
@@ -66,10 +66,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"key_derive\", \"params\": [\"equip will roof matter pink blind book anxiety banner elbow sun young\", \"m/44'/461'/0/0/0\"]}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"key_derive\",\n    \"params\": [\n        \"robust creek govern marriage super design group accuse soccer romance shrug blame broom render apart glass expire mom enforce six range gate dose organ\",\n        \"m/44'/461'/0/0/0\",\n        \"\",\n        \"en\"\n    ]\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
 						}
 					}
 				},
@@ -93,7 +93,7 @@
 			"response": []
 		},
 		{
-			"name": "transaction_create",
+			"name": "transaction_serialize",
 			"request": {
 				"auth": {
 					"type": "noauth"
@@ -109,10 +109,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"transaction_create\", \"params\": {\"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\", \"from\": \"t1b4zd6ryj5dsnwda5jtjxj6ptkia5e35s52ox7ka\", \"nonce\": 1, \"value\": \"100000\", \"gasprice\": \"2500\",\"gaslimit\": 25000, \"method\": 0, \"params\": \"\"}}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"transaction_serialize\",\n    \"params\": {\n        \"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\",\n        \"from\": \"t1b4zd6ryj5dsnwda5jtjxj6ptkia5e35s52ox7ka\",\n        \"nonce\": 1,\n        \"value\": \"100000\",\n        \"gasprice\": \"2500\",\n        \"gasFeeCap\": \"2500\",\n        \"gasPremium\": \"2500\",\n        \"gaslimit\": 25000,\n        \"method\": 0,\n        \"params\": \"\"\n    }\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
 						}
 					}
 				},
@@ -152,10 +152,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"transaction_parse\", \"params\": [\"885501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855010f323f4709e8e4db0c1d4cd374f9f35201d26fb20144000186a0430009c41961a80040\", true]}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"transaction_parse\",\n    \"params\": [\n        \"885501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855010f323f4709e8e4db0c1d4cd374f9f35201d26fb20144000186a0430009c41961a80040\",\n        true\n    ]\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
 						}
 					}
 				},
@@ -195,10 +195,182 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"sign_transaction\", \"params\": [{\n  \"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\",\n  \"from\": \"t1b4zd6ryj5dsnwda5jtjxj6ptkia5e35s52ox7ka\",\n  \"nonce\": 1,\n  \"value\": \"100000\",\n  \"gasprice\": \"2500\",\n  \"gaslimit\": 25000,\n  \"method\": 0,\n  \"params\": \"\"\n}, \"f15716d3b003b304b8055d9cc62e6b9c869d56cc930c3858d4d7c31f5f53f14a\"]}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"1\",\n    \"method\": \"sign_transaction\",\n    \"params\": [\n        {\n            \"to\": \"t17uoq6tp427uzv7fztkbsnn64iwotfrristwpryy\",\n            \"from\": \"f1jejt4mukbw4oh5c2mt3yyvpdif7l55lich5qo3i\",\n            \"nonce\": 1,\n            \"value\": \"100000\",\n            \"gasprice\": \"2500\",\n            \"gasFeeCap\": \"2500\",\n            \"gasPremium\": \"2500\",\n            \"gaslimit\": 25000,\n            \"method\": 0,\n            \"params\": \"\"\n        },\n        \"PYGdWyC0OOMtAS4ePlOA6XmEZbZcJfw9Bo12X6zVSuo=\"\n    ]\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://127.0.0.1:3030/v0/",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "3030",
+					"path": [
+						"v0",
+						""
+					]
+				},
+				"description": "Sign transaction"
+			},
+			"response": []
+		},
+		{
+			"name": "gen_create_multisig_tx",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"gen_create_multisig_tx\",\n    \"params\": [\n        {\n            \"from\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"nonce\": 1,\n            \"value\": \"1000\",\n            \"gasprice\": \"2500\",\n            \"gaslimit\": 1000000,\n            \"gasfeecap\": \"2500\",\n            \"gaspremium\": \"2500\",\n            \"signers\": [\n                \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n                \"t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy\"\n            ],\n            \"threshold\": 1,\n            \"unlock_duration\": 0,\n            \"start_epoch\": 0\n        }\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://127.0.0.1:3030/v0/",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "3030",
+					"path": [
+						"v0",
+						""
+					]
+				},
+				"description": "Sign transaction"
+			},
+			"response": []
+		},
+		{
+			"name": "propose_multisig_tx",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"propose_multisig_tx\",\n    \"params\": [\n        {\n            \"to\": \"t01004\",\n            \"from\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"nonce\": 1,\n            \"value\": \"0\",\n            \"gaslimit\": 1000000,\n            \"gasfeecap\": \"2500\",\n            \"gaspremium\": \"2500\",\n            \"method\": 2,\n            \"params\": \"hFUB3+SRhNRq3I+J1EY4vrRfePytJZBDAAPoAEA=\"\n        },\n        {\n            \"requester\": \"\",\n            \"to\": \"t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy\",\n            \"value\": \"1000\",\n            \"method\": 0,\n            \"params\": \"\"\n        }\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://127.0.0.1:3030/v0/",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "3030",
+					"path": [
+						"v0",
+						""
+					]
+				},
+				"description": "Sign transaction"
+			},
+			"response": []
+		},
+		{
+			"name": "approve_multisig_tx",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"approve_multisig_tx\",\n    \"params\": [\n        {\n            \"to\": \"t01004\",\n            \"from\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"nonce\": 1,\n            \"value\": \"0\",\n            \"gaslimit\": 1000000,\n            \"gasfeecap\": \"2500\",\n            \"gaspremium\": \"2500\",\n            \"method\": 3,\n            \"params\": \"ghkE0lgg+KzyZSly8Amuqh2bYc/NhnArMJPBnDBJYE8Z24yzePM=\"\n        },\n        {\n            \"requester\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"to\": \"t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy\",\n            \"value\": \"1000\",\n            \"method\": 0,\n            \"params\": \"\"\n        },\n        1234\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://127.0.0.1:3030/v0/",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "3030",
+					"path": [
+						"v0",
+						""
+					]
+				},
+				"description": "Sign transaction"
+			},
+			"response": []
+		},
+		{
+			"name": "cancel_multisig_tx",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"cancel_multisig_tx\",\n    \"params\": [\n        {\n            \"to\": \"t01004\",\n            \"from\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"nonce\": 1,\n            \"value\": \"0\",\n            \"gaslimit\": 1000000,\n            \"gasfeecap\": \"2500\",\n            \"gaspremium\": \"2500\",\n            \"method\": 4,\n            \"params\": \"ghkE0lgg+KzyZSly8Amuqh2bYc/NhnArMJPBnDBJYE8Z24yzePM=\"\n        },\n        {\n            \"requester\": \"t1d2xrzcslx7xlbbylc5c3d5lvandqw4iwl6epxba\",\n            \"to\": \"t137sjdbgunloi7couiy4l5nc7pd6k2jmq32vizpy\",\n            \"value\": \"1000\",\n            \"method\": 0,\n            \"params\": \"\"\n        },\n        1234\n    ]\n}",
+					"options": {
+						"raw": {
+							"language": "json"
 						}
 					}
 				},
@@ -238,10 +410,10 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", \"method\": \"verify_signature\", \"params\": [\"541025ca93d7d15508854520549f6a3c1582fbde1a511f21b12dcb3e49e8bdff3eb824cd8236c66b120b45941fd07252908131ffb1dffa003813b9f2bdd0c2f601\", \"885501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855010f323f4709e8e4db0c1d4cd374f9f35201d26fb20144000186a0430009c41961a80040\"]}",
+					"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": \"curltest\",\n    \"method\": \"verify_signature\",\n    \"params\": [\n        \"d4GDYWVIVl6zIXHShMppaVcJMvF1vumkCpsV7HlHRJM7Z59LY2tgV05ttNnqMIgwe4qL4sLIsrAuih1LdnwtSgE\",\n        \"885501fd1d0f4dfcd7e99afcb99a8326b7dc459d32c62855010f323f4709e8e4db0c1d4cd374f9f35201d26fb20144000186a0430009c41961a80040\"\n    ]\n}",
 					"options": {
 						"raw": {
-							"language": "text"
+							"language": "json"
 						}
 					}
 				},
@@ -264,6 +436,5 @@
 			},
 			"response": []
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/service/src/service/handlers.rs
+++ b/service/src/service/handlers.rs
@@ -46,6 +46,10 @@ async fn v0_post_methods(
         "get_nonce" => methods::get_nonce(method_call, config).await,
         "send_signed_tx" => methods::send_signed_tx(method_call, config).await,
         "send_sign" => methods::send_sign(method_call, config).await,
+        "gen_create_multisig_tx" => methods::create_multisig(method_call, config).await,
+        "propose_multisig_tx" => methods::propose_multisig_tx(method_call, config).await,
+        "approve_multisig_tx" => methods::approve_multisig_tx(method_call, config).await,
+        "cancel_multisig_tx" =>  methods::cancel_multisig_tx(method_call, config).await,
         _ => return Err(warp::reject::not_found()),
     };
 

--- a/service/src/service/handlers.rs
+++ b/service/src/service/handlers.rs
@@ -49,7 +49,7 @@ async fn v0_post_methods(
         "gen_create_multisig_tx" => methods::create_multisig(method_call, config).await,
         "propose_multisig_tx" => methods::propose_multisig_tx(method_call, config).await,
         "approve_multisig_tx" => methods::approve_multisig_tx(method_call, config).await,
-        "cancel_multisig_tx" =>  methods::cancel_multisig_tx(method_call, config).await,
+        "cancel_multisig_tx" => methods::cancel_multisig_tx(method_call, config).await,
         _ => return Err(warp::reject::not_found()),
     };
 

--- a/service/src/service/methods.rs
+++ b/service/src/service/methods.rs
@@ -3,7 +3,9 @@
 use crate::config::RemoteNodeSection;
 use crate::service::client;
 use crate::service::error::ServiceError;
-use filecoin_signer::api::{SignedMessageAPI, UnsignedMessageAPI, CreateMultisigMessageAPI, ProposalMessageParamsAPI};
+use filecoin_signer::api::{
+    CreateMultisigMessageAPI, ProposalMessageParamsAPI, SignedMessageAPI, UnsignedMessageAPI,
+};
 use filecoin_signer::signature::Signature;
 use filecoin_signer::{CborBuffer, PrivateKey};
 use jsonrpc_core::{MethodCall, Success, Version};
@@ -329,7 +331,7 @@ pub async fn create_multisig(c: MethodCall, _: RemoteNodeSection) -> Result<Succ
         tx_params.start_epoch,
         tx_params.gas_limit,
         tx_params.gas_fee_cap,
-        tx_params.gas_premium
+        tx_params.gas_premium,
     )?;
 
     let so = Success {
@@ -341,7 +343,10 @@ pub async fn create_multisig(c: MethodCall, _: RemoteNodeSection) -> Result<Succ
     Ok(so)
 }
 
-pub async fn propose_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
+pub async fn propose_multisig_tx(
+    c: MethodCall,
+    _: RemoteNodeSection,
+) -> Result<Success, ServiceError> {
     let params: ProposeMultisigTxParamsAPI = c.params.parse::<ProposeMultisigTxParamsAPI>()?;
 
     let tx: UnsignedMessageAPI = params.transaction;
@@ -357,7 +362,7 @@ pub async fn propose_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<
         tx.gas_fee_cap,
         tx.gas_premium,
         proposal_params.method,
-        proposal_params.params
+        proposal_params.params,
     )?;
 
     let so = Success {
@@ -369,8 +374,12 @@ pub async fn propose_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<
     Ok(so)
 }
 
-pub async fn approve_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
-    let params: ApproveCancelMultisigTxParamsAPI = c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
+pub async fn approve_multisig_tx(
+    c: MethodCall,
+    _: RemoteNodeSection,
+) -> Result<Success, ServiceError> {
+    let params: ApproveCancelMultisigTxParamsAPI =
+        c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
 
     let tx: UnsignedMessageAPI = params.transaction;
     let proposal_params: ProposalMessageParamsAPI = params.proposal_params;
@@ -385,7 +394,7 @@ pub async fn approve_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<
         tx.nonce,
         tx.gas_limit,
         tx.gas_fee_cap,
-        tx.gas_premium
+        tx.gas_premium,
     )?;
 
     let so = Success {
@@ -397,9 +406,12 @@ pub async fn approve_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<
     Ok(so)
 }
 
-
-pub async fn cancel_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
-    let params: ApproveCancelMultisigTxParamsAPI = c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
+pub async fn cancel_multisig_tx(
+    c: MethodCall,
+    _: RemoteNodeSection,
+) -> Result<Success, ServiceError> {
+    let params: ApproveCancelMultisigTxParamsAPI =
+        c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
 
     let tx: UnsignedMessageAPI = params.transaction;
     let proposal_params: ProposalMessageParamsAPI = params.proposal_params;
@@ -414,7 +426,7 @@ pub async fn cancel_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<S
         tx.nonce,
         tx.gas_limit,
         tx.gas_fee_cap,
-        tx.gas_premium
+        tx.gas_premium,
     )?;
 
     let so = Success {

--- a/service/src/service/methods.rs
+++ b/service/src/service/methods.rs
@@ -3,7 +3,7 @@
 use crate::config::RemoteNodeSection;
 use crate::service::client;
 use crate::service::error::ServiceError;
-use filecoin_signer::api::{SignedMessageAPI, UnsignedMessageAPI};
+use filecoin_signer::api::{SignedMessageAPI, UnsignedMessageAPI, CreateMultisigMessageAPI, ProposalMessageParamsAPI};
 use filecoin_signer::signature::Signature;
 use filecoin_signer::{CborBuffer, PrivateKey};
 use jsonrpc_core::{MethodCall, Success, Version};
@@ -11,6 +11,24 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value;
 use std::convert::TryFrom;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CreateMultisigParamsAPI {
+    pub tx_params: CreateMultisigMessageAPI,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProposeMultisigTxParamsAPI {
+    pub transaction: UnsignedMessageAPI,
+    pub proposal_params: ProposalMessageParamsAPI,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ApproveCancelMultisigTxParamsAPI {
+    pub transaction: UnsignedMessageAPI,
+    pub proposal_params: ProposalMessageParamsAPI,
+    pub txn_id: i64,
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SendSignedTxParamsAPI {
@@ -290,6 +308,118 @@ pub async fn send_sign(c: MethodCall, config: RemoteNodeSection) -> Result<Succe
     let so = Success {
         jsonrpc: Some(Version::V2),
         result,
+        id: c.id,
+    };
+
+    Ok(so)
+}
+
+pub async fn create_multisig(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
+    let params: CreateMultisigParamsAPI = c.params.parse::<CreateMultisigParamsAPI>()?;
+
+    let tx_params: CreateMultisigMessageAPI = params.tx_params;
+
+    let result: UnsignedMessageAPI = filecoin_signer::create_multisig(
+        tx_params.from,
+        tx_params.signers,
+        tx_params.value,
+        tx_params.threshold,
+        tx_params.nonce,
+        tx_params.unlock_duration,
+        tx_params.start_epoch,
+        tx_params.gas_limit,
+        tx_params.gas_fee_cap,
+        tx_params.gas_premium
+    )?;
+
+    let so = Success {
+        jsonrpc: Some(Version::V2),
+        result: serde_json::to_value(result)?,
+        id: c.id,
+    };
+
+    Ok(so)
+}
+
+pub async fn propose_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
+    let params: ProposeMultisigTxParamsAPI = c.params.parse::<ProposeMultisigTxParamsAPI>()?;
+
+    let tx: UnsignedMessageAPI = params.transaction;
+    let proposal_params: ProposalMessageParamsAPI = params.proposal_params;
+
+    let result: UnsignedMessageAPI = filecoin_signer::proposal_multisig_message(
+        tx.to,
+        proposal_params.to,
+        tx.from,
+        proposal_params.value,
+        tx.nonce,
+        tx.gas_limit,
+        tx.gas_fee_cap,
+        tx.gas_premium,
+        proposal_params.method,
+        proposal_params.params
+    )?;
+
+    let so = Success {
+        jsonrpc: Some(Version::V2),
+        result: serde_json::to_value(result)?,
+        id: c.id,
+    };
+
+    Ok(so)
+}
+
+pub async fn approve_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
+    let params: ApproveCancelMultisigTxParamsAPI = c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
+
+    let tx: UnsignedMessageAPI = params.transaction;
+    let proposal_params: ProposalMessageParamsAPI = params.proposal_params;
+
+    let result: UnsignedMessageAPI = filecoin_signer::approve_multisig_message(
+        tx.to,
+        params.txn_id,
+        proposal_params.requester,
+        proposal_params.to,
+        proposal_params.value,
+        tx.from,
+        tx.nonce,
+        tx.gas_limit,
+        tx.gas_fee_cap,
+        tx.gas_premium
+    )?;
+
+    let so = Success {
+        jsonrpc: Some(Version::V2),
+        result: serde_json::to_value(result)?,
+        id: c.id,
+    };
+
+    Ok(so)
+}
+
+
+pub async fn cancel_multisig_tx(c: MethodCall, _: RemoteNodeSection) -> Result<Success, ServiceError> {
+    let params: ApproveCancelMultisigTxParamsAPI = c.params.parse::<ApproveCancelMultisigTxParamsAPI>()?;
+
+    let tx: UnsignedMessageAPI = params.transaction;
+    let proposal_params: ProposalMessageParamsAPI = params.proposal_params;
+
+    let result: UnsignedMessageAPI = filecoin_signer::cancel_multisig_message(
+        tx.to,
+        params.txn_id,
+        proposal_params.requester,
+        proposal_params.to,
+        proposal_params.value,
+        tx.from,
+        tx.nonce,
+        tx.gas_limit,
+        tx.gas_fee_cap,
+        tx.gas_premium
+    )?;
+
+    let so = Success {
+        jsonrpc: Some(Version::V2),
+        result: serde_json::to_value(result)?,
         id: c.id,
     };
 

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -700,6 +700,72 @@ pub enum MessageTxAPI {
     SignedMessageAPI(SignedMessageAPI),
 }
 
+/// Create multisig message api structure
+#[cfg_attr(feature = "with-arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
+pub struct CreateMultisigMessageAPI {
+    #[serde(alias = "From")]
+    pub from: String,
+    #[serde(alias = "Nonce")]
+    pub nonce: u64,
+    #[serde(alias = "Value")]
+    pub value: String,
+
+    #[serde(rename = "gaslimit")]
+    #[serde(alias = "gasLimit")]
+    #[serde(alias = "gas_limit")]
+    #[serde(alias = "GasLimit")]
+    pub gas_limit: i64,
+
+    #[serde(rename = "gasfeecap")]
+    #[serde(alias = "gasFeeCap")]
+    #[serde(alias = "gas_fee_cap")]
+    #[serde(alias = "GasFeeCap")]
+    pub gas_fee_cap: String,
+
+    #[serde(rename = "gaspremium")]
+    #[serde(alias = "gasPremium")]
+    #[serde(alias = "gas_premium")]
+    #[serde(alias = "GasPremium")]
+    pub gas_premium: String,
+
+    #[serde(alias = "Signers")]
+    #[serde(alias = "signers")]
+    pub signers: Vec<String>,
+
+    #[serde(alias = "Threshold")]
+    #[serde(alias = "threshold")]
+    pub threshold: i64,
+
+    #[serde(alias = "UnlockDuration")]
+    #[serde(alias = "unlock_duration")]
+    pub unlock_duration: i64,
+
+    #[serde(alias = "StartEpoch")]
+    #[serde(alias = "start_epoch")]
+    pub start_epoch: i64,
+}
+
+/// Proposal message api structure
+#[cfg_attr(feature = "with-arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
+pub struct ProposalMessageParamsAPI {
+    #[serde(alias = "Requester")]
+    pub requester: String,
+
+    #[serde(alias = "To")]
+    pub to: String,
+
+    #[serde(alias = "Value")]
+    pub value: String,
+
+    #[serde(alias = "Method")]
+    pub method: u64,
+
+    #[serde(alias = "Params")]
+    pub params: String,
+}
+
 impl MessageTxAPI {
     pub fn get_message(&self) -> UnsignedMessageAPI {
         match self {


### PR DESCRIPTION
I am working on a project and it cannot use multisig's transaction signing on the Lotus Node.
This PR adds new RPCs to collect multisig transactions from raw data and updates Postman's collection.