### PR TITLE
main is for nodejs

### DIFF
--- a/signer-npm/package-signer.json
+++ b/signer-npm/package-signer.json
@@ -34,7 +34,7 @@
     "lowercase-keys": "^2.0.0",
     "secp256k1": "^4.0.1"
   },
-  "main": "./browser/filecoin_signer_wasm.js",
+  "main": "./nodejs/filecoin_signer_wasm.js",
   "exports": {
     ".": {
       "browser": "./browser/filecoin_signer_wasm.js",


### PR DESCRIPTION
Change "main" entrypoint to nodejs version. I do not know what was intent to set it to browser stuff, but the current version clearly breaks Jest. If browser version is used for "main", then this package should be exposed as ESM by setting `type: "module"` in `package.json.