### PR TITLE
Remove the `extras` folder in favor of the forest_actor crate

### DIFF
--- a/examples/wasm_node/test/tests_basic.js
+++ b/examples/wasm_node/test/tests_basic.js
@@ -442,6 +442,18 @@ describeCall('SerializeParams', function() {
       )
     })
   }
+
+  it('serialized parameters issue #423', function () {
+    const params = {
+      AmountRequested: "123"
+    }
+
+    let serialized_params = filecoin_signer.serializeParams(params)
+
+    console.log(serialized_params)
+
+    assert(false)
+  })
 })
 
 describeCall('DeserializeParams', function() {

--- a/extras/Cargo.toml
+++ b/extras/Cargo.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/Zondax/filecoin-signing-tools"
 description ="Temporary lib used for compatibility with wasm"
 
 [dependencies]
-forest_vm = "=0.3.1"
+forest_vm = "0.3.2"
 forest_message = { default-features = false, features = ["pairing"], version = "0.7" }
-forest_address = "=0.3.1"
-forest_encoding = "=0.2.1"
-forest_cid = {version = "=0.3.0", features = ["cbor"]}
+forest_address = "0.3.2"
+forest_encoding = "0.2.2"
+forest_cid = {version = "0.3.0", features = ["cbor"]}
 forest_crypto = { default-features = false, features = ["pairing"], version = "0.5.3" }
 multihash = "=0.13.1"
 multihash-derive = "=0.7.0"

--- a/extras/src/multisig.rs
+++ b/extras/src/multisig.rs
@@ -32,13 +32,6 @@ pub struct ConstructorParams {
     pub start_epoch: ChainEpoch,
 }
 
-/// Constructor parameters for multisig actor V1 (deprecated)
-#[derive(Serialize_tuple, Deserialize_tuple)]
-pub struct ConstructorParamsV1 {
-    pub signers: Vec<Address>,
-    pub num_approvals_threshold: i64,
-    pub unlock_duration: ChainEpoch,
-}
 
 /// Propose method call parameters
 #[derive(Serialize_tuple, Deserialize_tuple)]

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -16,9 +16,9 @@ serde_cbor = "0.11.1"
 serde_bytes = "0.11.5"
 rayon = "1"
 
-bls-signatures = {version = "0.10", default-features = false, features = ["pairing"]}
+bls-signatures = {version = "0.9", default-features = false, features = ["pairing"]}
 
-# Crypto related
+# Crypto related    
 hex = { git = "https://github.com/Zondax/rust-hex", rev="6e35fb48999278c8c6c75b099baa4ea2a9d1d12b" }
 getrandom="0.1.14"
 libsecp256k1 = "0.6"
@@ -35,19 +35,21 @@ arbitrary = { optional = true, features = ["derive"], version = "1" }
 ffi-support = { optional = true, version = "0.4" }
 
 
-forest_vm = "0.3.1"
-forest_address = "0.3.1"
-forest_encoding = "0.2.1"
+forest_vm = "0.3.2"
+forest_address = "0.3.2"
+forest_encoding = "0.2.2"
 forest_cid = { version ="0.3.0", features = ["cbor"] }
 forest_message = { default-features = false, features = ["pairing"], version = "0.7"  }
 forest_crypto = { default-features = false, features = ["pairing"], version = "0.5.3"  }
 
 tiny-bip39 = "0.8.0"
-num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.2"}
+num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.4"}
 
 zx-bip44 = "0.1.0"
 
-extras = { path = "../extras"}
+#extras = { path = "../extras"}
+extras = { package = "forest_actor", path = "../../forest/vm/actor", default-features = false, features = ["pairing"] }
+
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -41,6 +41,7 @@ forest_encoding = "0.2.2"
 forest_cid = { version ="0.3.0", features = ["cbor"] }
 forest_message = { default-features = false, features = ["pairing"], version = "0.7"  }
 forest_crypto = { default-features = false, features = ["pairing"], version = "0.5.3"  }
+clock = { package = "fil_clock", git = "https://github.com/chainsafe/forest", rev="d5a774a10b59dcad5372f520577180b9614fe2bb" }
 
 tiny-bip39 = "0.8.0"
 num_bigint_chainsafe = { package = "forest_bigint", version = "0.1.4"}

--- a/signer/src/multisigV1.rs
+++ b/signer/src/multisigV1.rs
@@ -1,0 +1,11 @@
+use clock::ChainEpoch;
+use forest_address::Address;
+use forest_encoding::tuple::*;
+
+/// Constructor parameters for multisig actor V1 (deprecated)
+#[derive(Serialize_tuple, Deserialize_tuple)]
+pub struct ConstructorParamsV1 {
+    pub signers: Vec<Address>,
+    pub num_approvals_threshold: usize,
+    pub unlock_duration: ChainEpoch,
+}


### PR DESCRIPTION
Still wip

## Abstract
Remove the `extras` folder in which we imported the actor sources files we needed for the lib. At that time we couldn't compile the crate to WASM because of some crypto dependencies.

This PR will remove those duplicated files but also allow better support for all the actors.

## TODO
- [ ] fix compile error
- [ ] Remove MessageParamsAPI if possible
- [ ] Tests
