### PR TITLE
fix the unlock_duration value missing

### DIFF
--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -70,7 +70,7 @@ impl Into<ConstructorParamsMultisig> for multisig::ConstructorParams {
         ConstructorParamsMultisig {
             signers,
             num_approvals_threshold: self.num_approvals_threshold,
-            unlock_duration: self.num_approvals_threshold,
+            unlock_duration: self.unlock_duration,
             start_epoch: self.start_epoch,
         }
     }


### PR DESCRIPTION
Fix the serialization/deserialization of parameters for multisig.

It didn't impact `create_multisig`.