### PR TITLE
feat: added publish crate action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,22 +84,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISH_AUTO }}
 
-
-#  rust_publish:
-#    needs: [ build ]
-#    if: ${{ github.ref == 'refs/heads/main' }}
-#    runs-on: ubuntu-latest
-#    container:
-#      image: zondax/rust-ci:latest
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#        with:
-#          submodules: true
-#      - name: Restore/Save sscache
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            ~/.cache/sccache
-#          key: ${{ runner.os }}-${{ github.run_id }}-${{ needs.configure.outputs.datetime }}
-#      # TODO: Enable cargo publish
+  rust_publish:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    container:
+      image: zondax/rust-ci:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Restore/Save sscache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/sccache
+          key: ${{ runner.os }}-${{ github.run_id }}-${{ needs.configure.outputs.datetime }}
+      - name: Cargo publish
+        run: cargo publish
+        env:
+           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,6 +47,7 @@ jobs:
 
   publish_npm_package:
     needs: [ build ]
+    if: startsWith("npm@")
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,14 +70,12 @@ jobs:
         run: npm install -g yarn
       - run: make install_wasmpack SILENT=true
       - run: make build_npm
-      - name: Get latest release version number
-        id: get_version
-        uses: battila7/get-version-action@v2
       - name: Update tag
         run: |
+          export TAG_NAME=${{ github.event.release.tag_name }}
           cd signer-npm/pkg
-          echo Publishing as ${{ steps.get_version.outputs.version }}
-          npm --allow-same-version --no-git-tag-version version ${{ steps.get_version.outputs.version }}
+          echo Publishing as ${TAG_NAME:4}
+          npm --allow-same-version --no-git-tag-version version ${TAG_NAME:4}
       - name: Publish package
         run: |
           cd signer-npm/pkg
@@ -86,7 +85,7 @@ jobs:
 
   rust_publish:
     needs: [ build ]
-    if: startsWith("filecoin_signer@")
+    if: startsWith("rust@")
     runs-on: ubuntu-latest
     container:
       image: zondax/rust-ci:latest
@@ -102,7 +101,10 @@ jobs:
             ~/.cache/sccache
           key: ${{ runner.os }}-${{ github.run_id }}-${{ needs.configure.outputs.datetime }}
       - name: Cargo publish
+        # version is inside the tag name e.g rust@v0.1.0 (and we don't want the v)
         run: |
+          export TAG_NAME=${{ github.event.release.tag_name }}
+          sed -i "s/0.0.0/${TAG_NAME:6}/g" Cargo.toml
           cargo publish -p filecoin-signer --allow-dirty
         env:
            CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,6 +86,7 @@ jobs:
 
   rust_publish:
     needs: [ build ]
+    if: startsWith("filecoin_signer@")
     runs-on: ubuntu-latest
     container:
       image: zondax/rust-ci:latest
@@ -101,6 +102,7 @@ jobs:
             ~/.cache/sccache
           key: ${{ runner.os }}-${{ github.run_id }}-${{ needs.configure.outputs.datetime }}
       - name: Cargo publish
-        run: cargo publish
+        run: |
+          cargo publish -p filecoin-signer --allow-dirty
         env:
            CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This PR uncomment the action that publish the crate and the the actual `cargo publish` step.

In order to avoid publishing the crate when publishing the npm package I ave added a condition that the tag name should start with `filecoin_signer@` so we can publish separately.

<!-- ClickUpRef: 8677up047 -->
:link: [zboto Link](https://app.clickup.com/t/8677up047)