### PR TITLE
fix: set version to '0.0.0' in Cargo.toml

### DIFF
--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filecoin-signer"
-version = "0.10.1"
+version = "0.0.0"
 authors = ["Zondax <info@zondax.ch>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Without this the CI action to publish wont work.

<!-- ClickUpRef: 8677uxvcq -->
:link: [zboto Link](https://app.clickup.com/t/8677uxvcq)