### PR TITLE
Update Zeroize Crate

### DIFF
--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -24,7 +24,7 @@ getrandom = "0.1.14"
 libsecp256k1 = "0.6"
 blake2b_simd = "0.5.10"
 hmac = "0.8.1"
-zeroize = { version = "=1.1", default-features = false, features = ["zeroize_derive"] }
+zeroize = { version = "^1.1", default-features = false, features = ["zeroize_derive"] }
 sha2 = "0.9.2"
 
 # logging

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -16,7 +16,7 @@ serde_cbor = "0.11.1"
 serde_bytes = "0.11.5"
 rayon = "1"
 
-bls-signatures = {version = "0.12.0", default-features = false, features = ["pairing"]}
+bls-signatures = {version = "0.13.0", default-features = false, features = ["pairing"]}
 
 # Crypto related
 hex = "0.4.3"

--- a/signer/src/api.rs
+++ b/signer/src/api.rs
@@ -121,7 +121,7 @@ impl MessageParams {
 }
 
 /// Structure containing an `UnsignedMessageAPI` or a `SignedMessageAPI`
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(untagged)]
 pub enum MessageTxAPI {
     #[serde(with = "MessageAPI")]


### PR DESCRIPTION
## Description:
The Zeroize crate current version creates dependency conflicts when used with crates such as `ethers-rs`. Updating the version to resolve those conflicts. 

<!-- ClickUpRef: 867804ufw -->
:link: [zboto Link](https://app.clickup.com/t/867804ufw)